### PR TITLE
Handle ImportError on python 3 while initializing library

### DIFF
--- a/scrapy_proxycrawl/__init__.py
+++ b/scrapy_proxycrawl/__init__.py
@@ -1,6 +1,6 @@
 try:
     # Python 2
     from proxycrawl import ProxyCrawlMiddleware
-except ModuleNotFoundError:
+except ImportError:
     # Python 3
     from .proxycrawl import ProxyCrawlMiddleware


### PR DESCRIPTION
Running python 3.7 this throws an ImportError (which is a superclass of ModuleNotFoundError)

ImportError: cannot import name 'ProxyCrawlMiddleware' from 'proxycrawl' (XXX/lib/python3.7/site-packages/proxycrawl/__init__.py)

Catching ImportError successfully makes us import from ".proxycrawl" on python 3

Tested this locally on python 3.7, Please let me know how to best test this 